### PR TITLE
Switch peer connection from TCP to UDP & TCP

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,13 +9,14 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 )
 
 func startClient(nodeAddress []string) {
 
 	reader := bufio.NewReader(os.Stdin)
 
-	// 부트스트랩 노드로부터 받은 주소들에 연결
+	// NodeDiscovery (Peer와 연결 직전까지)
 	if len(nodeAddress) > 0 {
 		for _, address := range nodeAddress {
 
@@ -24,14 +25,69 @@ func startClient(nodeAddress []string) {
 				continue
 			}
 
-			// 입력한 주소로 서버에 연결 시도
-			conn, err := net.Dial("tcp", address)
+			nodeUDPAddr, err := net.ResolveUDPAddr("udp", address)
 			if err != nil {
-				printError(fmt.Sprintf("Error reading from connection : %v", err))
+				printError(fmt.Sprintf("Error resolving UDP address : %v", err))
+				return
+			}
+			conn, err := net.DialUDP("udp", nil, nodeUDPAddr)
+			if err != nil {
+				printError(fmt.Sprintf("Error connecting to node : %v", err))
+				return
+			}
 
-			} else {
-				fmt.Println("Successfully connected to", address)
-				connectedPeers = append(connectedPeers, conn)
+			// 1. Send Ping
+			fmt.Println("Sending Ping to node")
+			pingMessage := []byte{NodeDiscoveryPing}
+			_, err = conn.Write(pingMessage)
+			if err != nil {
+				printError(fmt.Sprintf("Error sending Ping message : %v", err))
+				return
+			}
+
+			// 2. Waiting Pong
+			conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+			buffer := make([]byte, 1024)
+			n, _, err := conn.ReadFromUDP(buffer)
+			if err != nil {
+				printError(fmt.Sprintf("Error receiving Pong message : %v", err))
+				return
+			}
+			// 3. Send ENRRequest
+			if buffer[0] == NodeDiscoveryPong {
+				fmt.Println("Received Pong message")
+				fmt.Println("Sending ENRRequest")
+				_, err = conn.Write([]byte{NodeDiscoveryENRRequest})
+				if err != nil {
+					printError(fmt.Sprintf("Error sending ENRRequest : %v", err))
+					return
+				}
+
+				// 4. Waiting ENRResponse
+				conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+				n, _, err = conn.ReadFromUDP(buffer)
+				if err != nil {
+					printError(fmt.Sprintf("Error receiving ENRResponse : %v", err))
+					return
+				}
+
+				if buffer[0] == NodeDiscoveryENRResponse {
+					tcpServer := string(buffer[1:n])
+					fmt.Println("TCP SERVER :::", tcpServer)
+					// 3. TCP 연결
+
+					// 주소로 UDP Ping 보내기
+					conn, err := net.Dial("tcp", tcpServer)
+					if err != nil {
+						printError(fmt.Sprintf("Error reading from connection : %v", err))
+
+					} else {
+						fmt.Println("Successfully connected to", tcpServer)
+						connectedPeers = append(connectedPeers, conn)
+					}
+
+				}
+
 			}
 
 		}

--- a/main.go
+++ b/main.go
@@ -16,23 +16,25 @@ func main() {
 	// 명령줄 인자 파싱 (flag.Parse() 필수)
 	flag.Parse()
 
-	serverListening := make(chan string)
-
+	tcpAddress := make(chan string)
+	udpAddress := make(chan string)
 	bootstrapAddress := "localhost:8282"
 
 	if *mode == "bootstrap" {
 		startBootstrapServer()
 
 	} else if *mode == "fullNode" {
-		// 1. TCP,UDP 서버 실행
-		go startTCPServer(serverListening, *port)
-		go startUDPServer(*port)
+		// 1. TCP 서버 실행
+		go startTCPServer(tcpAddress, *port)
 
-		// 2. 서버 주소 받아옴
-		serverAddress := <-serverListening
+		// 2. UDP 서버 실행
+		go startUDPServer(udpAddress, tcpAddress, *port)
+
+		// 3. UDP 서버 주소 받아옴
+		udpServerAddress := <-udpAddress
 
 		// 3. 부트스트랩 노드에 연결하고, 내 서버 정보 전달
-		nodeAddress := connectBootstrapNode(bootstrapAddress, serverAddress)
+		nodeAddress := connectBootstrapNode(bootstrapAddress, udpServerAddress)
 		fmt.Println("부트스트랩 노드로부터 받은 노드들 주소 :", nodeAddress)
 
 		// 4. 받은 노드들과 연결 시도


### PR DESCRIPTION
Initial peer connection now uses UDP for Ping-Pong messages. 
Added ENRResponse to retrieve TCP address, and established subsequent TCP connection.